### PR TITLE
fix: change package name back to yas

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ts-webdev",
+  "name": "yas",
   "version": "0.0.0",
   "private": true,
   "license": "MIT",
@@ -39,7 +39,7 @@
     "turbo": "2.0.3"
   },
   "engines": {
-    "node": "20.10.0"
+    "node": "^20.10.0"
   },
   "packageManager": "pnpm@9.2.0+sha256.94fab213df221c55b6956b14a2264c21c6203cca9f0b3b95ff2fe9b84b120390"
 }


### PR DESCRIPTION
Changes name of package back to `yas` so that the app will build properly.
Also changes engine to accept node versions >= 20.10.0